### PR TITLE
feat: create release 1.13

### DIFF
--- a/charts/statgpt/Chart.yaml
+++ b/charts/statgpt/Chart.yaml
@@ -64,4 +64,4 @@ maintainers:
 name: statgpt
 sources:
   - https://github.com/epam/statgpt-helm
-version: 1.12.0
+version: 1.13.0

--- a/charts/statgpt/README.md
+++ b/charts/statgpt/README.md
@@ -1,6 +1,6 @@
 # statgpt
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Umbrella chart for StatGPT solution
 
@@ -97,10 +97,10 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | _admin_frontend_version | string | `"0.4.2"` | Admin Frontend version is used for the admin-frontend image tag |
-| _backend_version | string | `"0.12.0"` | Backend version is used for both chat-backend and admin-backend image tags (must be the same for both) |
+| _backend_version | string | `"0.13.0"` | Backend version is used for both chat-backend and admin-backend image tags (must be the same for both) |
 | _elasticsearch_version | string | `"8.14.3-debian-12-r0"` | Elasticsearch version is used for the elasticsearch image tag |
 | _pgvector_version | string | `"v0.8.1"` | PGVector extension version |
-| _portal-frontend_version | string | `"0.6.2"` | Portal Frontend version is used for the portal-frontend image tag |
+| _portal-frontend_version | string | `"0.6.3"` | Portal Frontend version is used for the portal-frontend image tag |
 | _postgresql_version | string | `"16.3.0-debian-12-r14"` | PostgreSQL version is used for the postgresql image tag |
 | _sdmx_proxy_version | string | `"0.4.0"` | SDMX Proxy version is used for both sdmx-proxy and sdmx-proxy-config-server image tags (must be the same for both) |
 | admin-backend.autoUpdateCronJob.backoffLimit | int | `2` | Number of retries before considering a Job as failed |
@@ -143,7 +143,7 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 | admin-backend.image.pullPolicy | string | `"Always"` | Image pull policy |
 | admin-backend.image.registry | string | `"docker.io"` | Docker registry URL |
 | admin-backend.image.repository | string | `"epam/statgpt-admin-backend"` | Image repository name |
-| admin-backend.image.tag | string | `"0.12.0"` | Image tag or version |
+| admin-backend.image.tag | string | `"0.13.0"` | Image tag or version |
 | admin-backend.ingress | object | `{"annotations":{"nginx.ingress.kubernetes.io/proxy-connect-timeout":"600","nginx.ingress.kubernetes.io/proxy-read-timeout":"600","nginx.ingress.kubernetes.io/proxy-send-timeout":"600"},"enabled":false,"ingressClassName":"nginx","path":"/admin/api"}` | Example for data related variables DATA_PORTAL_API_KEY: "example" ## Ingress Configuration ### ref: https://kubernetes.io/docs/concepts/services-networking/ingress/ |
 | admin-backend.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-connect-timeout":"600","nginx.ingress.kubernetes.io/proxy-read-timeout":"600","nginx.ingress.kubernetes.io/proxy-send-timeout":"600"}` | NGINX annotations for proxy configuration |
 | admin-backend.ingress.enabled | bool | `false` | Enable Ingress resource |
@@ -236,7 +236,7 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 | chat-backend.image.pullPolicy | string | `"Always"` | Image pull policy |
 | chat-backend.image.registry | string | `"docker.io"` | Docker registry URL |
 | chat-backend.image.repository | string | `"epam/statgpt-chat-backend"` | Image repository name |
-| chat-backend.image.tag | string | `"0.12.0"` | Image tag or version |
+| chat-backend.image.tag | string | `"0.13.0"` | Image tag or version |
 | chat-backend.livenessProbe.enabled | bool | `true` | Enable livenessProbe |
 | chat-backend.livenessProbe.initialDelaySeconds | int | `180` | Initial delay in seconds before liveness probe starts (increased to prevent premature pod restarts during PostgreSQL initialization) |
 | chat-backend.metrics.enabled | bool | `false` | Enable metrics collection |
@@ -299,7 +299,7 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 | portal-frontend.image.pullPolicy | string | `"Always"` | Image pull policy |
 | portal-frontend.image.registry | string | `"docker.io"` | Docker registry URL |
 | portal-frontend.image.repository | string | `"epam/statgpt-global-trusted-data-commons"` | Image repository name |
-| portal-frontend.image.tag | string | `"0.6.2"` | Image tag or version |
+| portal-frontend.image.tag | string | `"0.6.3"` | Image tag or version |
 | portal-frontend.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-connect-timeout":"600","nginx.ingress.kubernetes.io/proxy-read-timeout":"600","nginx.ingress.kubernetes.io/proxy-send-timeout":"600"}` | NGINX annotations for proxy configuration |
 | portal-frontend.ingress.enabled | bool | `false` | Enable Ingress resource |
 | portal-frontend.ingress.ingressClassName | string | `"nginx"` | Specify the Ingress class name |

--- a/charts/statgpt/README.md
+++ b/charts/statgpt/README.md
@@ -96,7 +96,7 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| _admin_frontend_version | string | `"0.4.2"` | Admin Frontend version is used for the admin-frontend image tag |
+| _admin_frontend_version | string | `"0.4.3"` | Admin Frontend version is used for the admin-frontend image tag |
 | _backend_version | string | `"0.13.0"` | Backend version is used for both chat-backend and admin-backend image tags (must be the same for both) |
 | _elasticsearch_version | string | `"8.14.3-debian-12-r0"` | Elasticsearch version is used for the elasticsearch image tag |
 | _pgvector_version | string | `"v0.8.1"` | PGVector extension version |
@@ -195,7 +195,7 @@ helm install my-release . --namespace my-namespace --values values.yaml --set ad
 | admin-frontend.image.pullPolicy | string | `"Always"` | Image pull policy |
 | admin-frontend.image.registry | string | `"docker.io"` | Docker registry URL |
 | admin-frontend.image.repository | string | `"epam/statgpt-admin-frontend"` | Image repository name |
-| admin-frontend.image.tag | string | `"0.4.2"` | Image tag or version |
+| admin-frontend.image.tag | string | `"0.4.3"` | Image tag or version |
 | admin-frontend.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-connect-timeout":"600","nginx.ingress.kubernetes.io/proxy-read-timeout":"600","nginx.ingress.kubernetes.io/proxy-send-timeout":"600"}` | NGINX annotations for proxy configuration |
 | admin-frontend.ingress.enabled | bool | `false` | Enable Ingress resource |
 | admin-frontend.ingress.ingressClassName | string | `"nginx"` | Specify the Ingress class name |

--- a/charts/statgpt/values.yaml
+++ b/charts/statgpt/values.yaml
@@ -1,7 +1,7 @@
 # -- Backend version is used for both chat-backend and admin-backend image tags (must be the same for both)
 _backend_version: &backend_version "0.13.0"
 # -- Admin Frontend version is used for the admin-frontend image tag
-_admin_frontend_version: &admin_frontend_version "0.4.2"
+_admin_frontend_version: &admin_frontend_version "0.4.3"
 # -- Portal Frontend version is used for the portal-frontend image tag
 _portal-frontend_version: &portal-frontend_version "0.6.3"
 # -- SDMX Proxy version is used for both sdmx-proxy and sdmx-proxy-config-server image tags (must be the same for both)

--- a/charts/statgpt/values.yaml
+++ b/charts/statgpt/values.yaml
@@ -1,9 +1,9 @@
 # -- Backend version is used for both chat-backend and admin-backend image tags (must be the same for both)
-_backend_version: &backend_version "0.12.0"
+_backend_version: &backend_version "0.13.0"
 # -- Admin Frontend version is used for the admin-frontend image tag
 _admin_frontend_version: &admin_frontend_version "0.4.2"
 # -- Portal Frontend version is used for the portal-frontend image tag
-_portal-frontend_version: &portal-frontend_version "0.6.2"
+_portal-frontend_version: &portal-frontend_version "0.6.3"
 # -- SDMX Proxy version is used for both sdmx-proxy and sdmx-proxy-config-server image tags (must be the same for both)
 _sdmx_proxy_version: &sdmx_proxy_version "0.4.0"
 # -- PostgreSQL version is used for the postgresql image tag


### PR DESCRIPTION
### Description of changes

Create chart release **1.13.0** — bump core component versions:

| Component | Previous | New |
|---|---|---|
| `statgpt-backend` (chat-backend, admin-backend) | 0.12.0 | **0.13.0** |
| `statgpt-global-trusted-data-commons` (portal-frontend) | 0.6.2 | **0.6.3** |
| `statgpt-admin-frontend` | 0.4.2 | **0.4.3** |
| `statgpt-sdmx-proxy` (sdmx-proxy, sdmx-proxy-config-server) | 0.4.0 | 0.4.0 (unchanged) |

No deployment changes are required by the new component versions. README regenerated with helm-docs.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
