### PR TITLE
chore: add CLAUDE.md and release preparation skill for Claude Code

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -127,6 +127,28 @@ as feature descriptions. Component notes sometimes deprecate *application/channe
 config* fields (not values-file vars) — those are not deployment changes; if
 relevant to operators, add them as a short blockquote note instead.
 
+## Refreshing an open release PR
+
+Components often release while the chart release PR is still open. In that case do
+not start a new release — refresh the existing PR:
+
+1. Find it: `gh pr list --state open --search "create release in:title"` (or the
+   open `feat/release-*` / `chore/patch-*` branch) and check out its branch.
+2. Re-run Step 1 for the newly released component(s) only; confirm the delta with
+   the user (Step 2). Re-check the minor-vs-patch calculus — a new component
+   version with features or deployment changes can upgrade a patch PR to a minor
+   one, which means retitling the PR and renaming nothing (keep the branch; PRs are
+   squash-merged under the PR title, so only the title must be correct).
+3. Apply the additional bumps exactly as in Step 3 (anchor, deployment-change
+   edits, helm-docs regeneration, render check) and push a follow-up commit — no
+   need to amend or force-push.
+4. Update the PR description's version table, and **edit** the existing
+   release-notes draft comment rather than posting a second one:
+   ```sh
+   gh api repos/epam/statgpt-helm/issues/comments/<comment-id> -X PATCH -f body='...'
+   ```
+   (find the comment id via `gh api repos/epam/statgpt-helm/issues/<pr>/comments`).
+
 ## Cautions
 
 - Confirm with the user before pushing the branch / opening the PR.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -25,6 +25,21 @@ Paired components (backend×2, sdmx-proxy×2) must stay on the same version — 
 why the anchors exist. Always edit the anchor at the top of values.yaml, never the
 individual `image.tag` fields.
 
+## Arguments
+
+The skill accepts optional free-text arguments that pre-answer decisions normally
+made in Steps 1–2:
+
+- `1.14` or `1.13.1` — the target chart version (also implies minor vs patch).
+- `patch` / `minor` — force the bump type when the heuristic would guess wrong.
+- `<component>=<version>` (e.g. `admin-frontend=0.4.3 backend=0.12.0`) — pin a
+  component, including holding one back from its latest release.
+
+Arguments narrow choices; they do not skip work. Still run the full Step 1
+collection for **all** components and still show the Step 2 confirmation table —
+with the pins pre-applied and any other available bumps visible — so the user sees
+the whole picture before anything is edited.
+
 ## Step 1 — Collect versions
 
 1. Read the current anchors from the top of `charts/statgpt/values.yaml` and the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: release
+description: Prepare a StatGPT helm chart release — collect new component versions from the source repos, confirm targets with the user, open the release PR (version anchors, Chart.yaml, regenerated README), and attach a release-notes draft. Use whenever the user wants to cut/create/prepare a chart release or patch, bump component versions, check whether a release is due, or draft chart release notes — even if they just say "backend 0.X is out, update the chart".
+---
+
+# StatGPT Chart Release
+
+Prepares a release of the `statgpt` umbrella chart. The chart pins application
+versions via YAML anchors in `charts/statgpt/values.yaml`; releasing means bumping
+those anchors + the chart version, regenerating docs, and opening a PR. Publishing
+itself is automated: when the PR merges to `main`, chart-releaser packages any chart
+whose `version` changed and creates the GitHub release. Release notes are managed by
+CI/humans after that — this skill only produces the **draft** and attaches it to the PR.
+
+## Component → source repo mapping
+
+| values.yaml anchor | Source repo (releases + notes) | Chart components using it |
+|---|---|---|
+| `_backend_version` | `epam/statgpt-backend` | chat-backend, admin-backend |
+| `_admin_frontend_version` | `epam/statgpt-admin-frontend` | admin-frontend |
+| `_portal-frontend_version` | `epam/statgpt-global-trusted-data-commons` | portal-frontend |
+| `_sdmx_proxy_version` | `epam/statgpt-sdmx-proxy` | sdmx-proxy, sdmx-proxy-config-server |
+
+Paired components (backend×2, sdmx-proxy×2) must stay on the same version — that is
+why the anchors exist. Always edit the anchor at the top of values.yaml, never the
+individual `image.tag` fields.
+
+## Step 1 — Collect versions
+
+1. Read the current anchors from the top of `charts/statgpt/values.yaml` and the
+   current chart `version` from `charts/statgpt/Chart.yaml`.
+2. For each source repo: `gh release list -R epam/<repo> --limit 10`.
+3. For every component that is behind, fetch the release notes of **every
+   intermediate version**, not just the latest
+   (`gh release view <tag> -R epam/<repo> --json body -q '.body'`).
+   A chart that skips from 0.11.0 to 0.13.0 must aggregate the changelogs of 0.12.0
+   *and* 0.13.0 — deployment changes in a skipped version still apply to upgraders.
+4. From each release body, extract:
+   - notable Features/Fixes bullets (for "What's Changed"),
+   - the "Deployment Changes" section (some repos spell it "Deployment changes").
+     Anything other than "no deployment changes" means the chart's `values.yaml`
+     env/secret schema likely needs edits (renames, new vars, removed vars) — these
+     are the changes release 1.12 made (`NEXTAUTH_URL`→`AUTH_URL` etc.).
+
+## Step 2 — Confirm with the user
+
+Propose the target chart version:
+- **Minor** (`X.(Y+1).0`) when any component bump brings features or deployment
+  changes — PR/commit title `feat: create release X.Y`, branch `feat/release-X.Y`.
+- **Patch** (`X.Y.(Z+1)`) when only fixes/patch bumps — title
+  `chore: create patch X.Y.Z`, branch `chore/patch-X.Y.Z`.
+
+Present a table (component | current | proposed | deployment changes?) and confirm
+with AskUserQuestion: the target chart version and each component version (the user
+may want to hold a component back). Also surface any deployment changes verbatim and
+agree on how they map to values.yaml edits before touching files.
+
+## Step 3 — Prepare the PR
+
+1. Create the branch from up-to-date `main`.
+2. Edit the version anchors in `charts/statgpt/values.yaml`.
+3. Apply values schema changes implied by the components' deployment changes
+   (env/secret renames, new vars with sensible defaults, removals). Keep the `# --`
+   helm-docs comment on every new/renamed key — the README is generated from them.
+   Check whether `charts/statgpt/ci/default-values.yaml` and
+   `charts/statgpt/examples/*/values.yaml` reference renamed/removed vars and update
+   them too.
+4. Bump `version` in `charts/statgpt/Chart.yaml` (leave `appVersion` alone unless
+   the user asks).
+5. Regenerate the README — never hand-edit it (CI fails if it is stale):
+   ```sh
+   docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.11.3 --chart-search-root=charts/statgpt
+   ```
+6. Sanity-check rendering before pushing:
+   ```sh
+   cd charts/statgpt && helm dependency update && \
+   helm template statgpt . --values values.yaml --values ci/default-values.yaml >/dev/null
+   ```
+   Then confirm every component renders the intended tag:
+   ```sh
+   helm template statgpt . --values values.yaml --values ci/default-values.yaml \
+     | grep -o 'image: "docker.io/epam/[^"]*"' | sort -u
+   ```
+   `helm dependency update` leaves untracked artifacts (`Chart.lock`,
+   `charts/statgpt/charts/*.tgz`) — never commit them.
+7. Commit **only** `Chart.yaml`, `values.yaml`, `README.md` (plus any
+   ci/examples values files edited in step 3) with a conventional title matching
+   the PR title, push, and open the PR using the repo PR template — fill
+   "Description of changes" with the component bump summary, tick the Conventional
+   Commits checkbox, drop the unused "fixes #" line.
+8. Post the release-notes draft (Step 4) as a PR comment, prefixed with a line like
+   `Release notes draft for statgpt-X.Y.Z — for use when editing the GitHub release
+   after merge:`.
+
+## Step 4 — Release-notes draft
+
+Follow the established format exactly (see any recent release, e.g.
+`gh release view statgpt-1.12.0`). Template:
+
+```markdown
+Umbrella chart for StatGPT solution
+
+## Core Components
+
+* `statgpt-backend`: [<v>](https://github.com/epam/statgpt-backend/releases/tag/<v>)
+* `statgpt-admin-frontend`: [<v>](https://github.com/epam/statgpt-admin-frontend/releases/tag/<v>)
+* `statgpt-global-trusted-data-commons`: [<v>](https://github.com/epam/statgpt-global-trusted-data-commons/releases/tag/<v>)
+* `sdmx-proxy`: [<v>](https://github.com/epam/statgpt-sdmx-proxy/releases/tag/<v>)
+
+## What's Changed
+
+* The versions of the core components have been updated.
+* <one bullet per other notable chart-level change, if any>
+
+## Deployment Changes
+
+<For each component with migration steps, a "### <component>" subsection with
+concrete instructions (rename X→Y, add Z, remove W) aggregated across ALL
+intermediate versions. If none:>
+No deployment changes required for this release.
+```
+
+List **all four** components in Core Components with the versions the chart now
+pins, including ones that didn't change. "Deployment Changes" is written for chart
+*operators* — phrase entries as actions against their environment values files, not
+as feature descriptions. Component notes sometimes deprecate *application/channel
+config* fields (not values-file vars) — those are not deployment changes; if
+relevant to operators, add them as a short blockquote note instead.
+
+## Cautions
+
+- Confirm with the user before pushing the branch / opening the PR.
+- If a component's deployment changes are ambiguous (e.g., a new var whose default
+  is unclear), ask rather than guessing a default into values.yaml.
+- Merging the PR triggers the actual release — never merge it yourself.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Helm dependency artifacts (created by `helm dependency update`)
+Chart.lock
+/charts/*/charts/
+
+# IDEs
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+
+# Logs
+*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+This is a **Helm chart repository** (not application source code). It publishes a single umbrella chart, `statgpt`, that deploys the StatGPT solution — an AI DIAL–based conversational analytics application over SDMX statistics data. Chart packages are released to GitHub Pages (`https://epam.github.io/statgpt-helm`) and consumed with `helm repo add statgpt ...`. The actual application code lives in separate repos (`epam/statgpt`, DIAL charts at `https://charts.dialx.ai`).
+
+Everything of substance lives under `charts/statgpt/`.
+
+## Architecture
+
+The umbrella chart has almost no templates of its own. Its behavior is composed from subchart dependencies declared in `charts/statgpt/Chart.yaml`:
+
+- **Six application components are all aliases of the same `dial-extension` chart** (packaged repo `https://charts.dialx.ai`; source at [`github.com/epam/ai-dial-helm`](https://github.com/epam/ai-dial-helm)): `chat-backend`, `admin-backend`, `admin-frontend`, `portal-frontend`, `sdmx-proxy`, `sdmx-proxy-config-server`. Each is gated by a `<name>.enabled` condition. Because they share one chart, they all expose the **same value schema** (`image`, `env`, `secrets`, `resources`, `livenessProbe`/`readinessProbe`, `serviceAccount`, `podSecurityContext`, `extraVolumes`, `extraDeploy`, etc.). The Deployment, Service, Secret creation, and env/secret mounting all come from `dial-extension` — not from this repo. To understand how a component renders, read the `dial-extension` chart source in `epam/ai-dial-helm`, not `charts/statgpt/templates/`.
+- **Stateful dependencies** come from Bitnami: `pgvector` (a `postgresql` alias with the pgvector extension), `elasticsearch`, and `common` (the Bitnami helper library used by the local templates).
+
+The only first-party templates in `charts/statgpt/templates/`:
+- `admin-backend-auto-update-cronjob.yaml` — a CronJob that runs the admin-backend image with `ADMIN_MODE=AUTO_UPDATE`, gated on `admin-backend.autoUpdateCronJob.enabled`. It re-derives env/secret wiring from `admin-backend.*` values.
+- `extra-list.yaml` — renders arbitrary manifests from the top-level `extraDeploy` list.
+- `_helpers.tpl` is intentionally empty; helpers come from the Bitnami `common` chart.
+
+### values.yaml conventions
+
+`charts/statgpt/values.yaml` is the single source of truth for configuration and is heavily commented.
+
+- **Version anchors** at the top of the file pin image tags via YAML anchors (`&backend_version`, `&sdmx_proxy_version`, etc.). Constraints encoded there: `chat-backend` and `admin-backend` **must share** `backend_version`; `sdmx-proxy` and `sdmx-proxy-config-server` **must share** `sdmx_proxy_version`. Change the anchor, not individual tags.
+- Shipped defaults have components `enabled: false` and sensitive/site-specific values set to `"environment-specific"` placeholders. Real deployments layer an env-specific values file on top (see `charts/statgpt/examples/`).
+- `charts/statgpt/ci/default-values.yaml` is a separate, self-contained values file used only by CI to make an installable release; it uses its own anchors to share `env`/`secrets` (DIAL, pgvector, elastic credentials) across components.
+
+## Common commands
+
+Run chart commands from `charts/statgpt/` unless noted.
+
+```sh
+# Fetch/refresh subchart dependencies (required before template/install)
+helm dependency update
+
+# Preview rendered manifests
+helm template my-release . --namespace my-namespace --values values.yaml
+# ...layered with an environment file:
+helm template my-release . --namespace my-namespace --values values.yaml --values examples/generic/values.yaml
+
+helm install my-release . --namespace my-namespace --values values.yaml
+```
+
+### Lint & test (mirrors CI, run from repo root)
+
+CI uses [chart-testing](https://github.com/helm/chart-testing) (`ct`) configured by `ct.yaml`.
+
+```sh
+ct list-changed --config ct.yaml   # which charts changed vs main
+ct lint --config ct.yaml           # lint changed charts (needs Python: yamale + yamllint)
+ct install --config ct.yaml        # install changed charts into a kind cluster
+```
+
+`.pre-commit-config.yaml` runs `check-yaml` (which **excludes** `charts/statgpt/templates/*.yaml|yml` because they contain Helm templating), plus end-of-file / whitespace / line-ending fixers.
+
+### Regenerating docs — important
+
+`charts/statgpt/README.md` is **generated** by [helm-docs](https://github.com/norwoodj/helm-docs) from `values.yaml` comments plus `README.md.gotmpl`. **Never hand-edit `charts/statgpt/README.md`.** To change documented parameters, edit the `# --` annotation comments in `values.yaml`, then regenerate:
+
+```sh
+# from repo root
+docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.11.3 --chart-search-root=charts/statgpt
+```
+
+The `lint-test` workflow fails if `README.md` is out of date relative to `values.yaml`.
+
+## Release & contribution workflow
+
+- **Releasing is automated.** On push to `main`, `.github/workflows/release.yaml` runs `chart-releaser`, packages any chart whose version changed, and publishes it. Therefore a change is released only if you **bump `version` in `charts/statgpt/Chart.yaml`**. `appVersion` tracks the app, `version` tracks the chart. Release PRs by convention are titled `feat: create release X.Y` / `chore: create patch X.Y.Z` and bump `Chart.yaml` version + regenerate `README.md` together.
+- **PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)** — enforced by `pr-title-check.yml` (delegates to `epam/ai-dial-ci`).
+- The root `README.md` is auto-synced to the `gh-pages` branch on change (`sync-readme.yaml`); keep links in it as full `https://github.com/...` URLs since it is served from gh-pages.
+
+## Notes
+
+- Cross-component env wiring assumes the `fullnameOverride` naming shown in `ci/default-values.yaml` (e.g. `PGVECTOR_HOST: statgpt-pgvector`, `ELASTIC_CONNECTION_STRING: http://statgpt-elasticsearch:9200`). Changing a component's `fullnameOverride` requires updating every reference to it.
+- `charts/statgpt/examples/azure/` shows the production-oriented pattern: Azure Workload Identity + CSI `SecretProviderClass` (via `extraDeploy`) instead of plaintext `secrets`, and `PGVECTOR_USE_MSI` for passwordless Postgres. `examples/generic/` is a minimal, non-production plaintext-secret walkthrough.


### PR DESCRIPTION
### Description of changes

Add Claude Code project documentation, automation, and repo hygiene:

- **`CLAUDE.md`** — repository guide for Claude Code: umbrella-chart architecture (dial-extension aliases, version anchors), lint/test commands mirroring CI (`ct`, helm-docs), and the release/versioning conventions (chart-releaser on version bump, generated README, Conventional Commits).
- **`.claude/skills/release/SKILL.md`** — a `/release` skill that prepares a chart release: collects component versions from the four source repos, confirms targets with the user, opens the release PR (version anchors + `Chart.yaml` + regenerated README), and attaches a release-notes draft in the established format. Validated end-to-end by preparing #66.
- **`.gitignore`** — ignore `helm dependency update` artifacts (`Chart.lock`, downloaded subcharts under `charts/*/charts/`), IDE directories, OS files, and logs. Anchored so the top-level `charts/` directory itself is unaffected; verified no currently tracked file matches the new rules.

No chart changes — nothing is packaged or released from these files.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.